### PR TITLE
bump scala verstion to 2.13.0-M5

### DIFF
--- a/sbt.conf
+++ b/sbt.conf
@@ -1,6 +1,6 @@
 vars: {
   scala213-bin-version: "2.13"
-  scala213-version: ${vars.scala213-bin-version}".0-M4"
+  scala213-version: ${vars.scala213-bin-version}".0-M5"
 
   scala212-bin-version: "2.12"
   scala212-version: ${vars.scala212-bin-version}".7"


### PR DESCRIPTION
Currently nightly build of sbt are broken because of `io` module.

The root cause is:
```
sbt.librarymanagement.ResolveException: unresolved dependency: org.scalatest#scalatest_2.13.0-M4;3.0.6-SNAP3: not found
```
scalatest is published in `SNAP2` for `M4` and in `SNAP3` for `M5` so dbuild fails in compiling `io` with scala 2.13.

The way to go ahead IMO is to bump here the version of scala and fix whatever else get broken.